### PR TITLE
Load CORS middleware before rate-limiter

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -38,6 +38,8 @@ const startApp = () => {
   const app = express();
   app.set('trust proxy', 1);
 
+  app.use(require('cors')());
+
   const rateLimitOpts = {
     windowMs: 1000 * 10,
     max: 10,
@@ -51,7 +53,6 @@ const startApp = () => {
   app.use('/static/', require('express-rate-limit')(rateLimitOpts));
 
   app.use(require('body-parser').json());
-  app.use(require('cors')());
 
   app.use(notmatches('/static', secretCheck));
 


### PR DESCRIPTION
Should resolve #484

---

I spent the last few hours trying to get the web client running locally to verify this works as I expected. Got stuck on some metamask integration failing on my local.